### PR TITLE
Coinblocks change after question answered correctly

### DIFF
--- a/Checkmate2019/Base/urls.py
+++ b/Checkmate2019/Base/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path("game/", views.game, name="game"),
     path("check_answer/", views.check_answer, name="check_answer"),
     path("display_score/", views.display_score, name="display_score"),
+    path("get_question_list", views.get_question_list, name="get_question_list")
 ]

--- a/Checkmate2019/Base/views.py
+++ b/Checkmate2019/Base/views.py
@@ -21,6 +21,14 @@ def index(request):
         return render(request, "Base/index.html", {})
     return render(request, "Base/index.html", {})
 
+def get_question_list(request):
+    current_team = Team.objects.get(user = request.user)
+    dushyant = current_team.questions_answered.all()
+    dushyant_list = []
+    for x in dushyant:
+        dushyant_list.append(x.id)
+    data = {'correct_list':dushyant_list}
+    return JsonResponse(data)
     
 def sign_up(request):
     if not request.user.is_authenticated: # This is to check that when user is logged in, he is not able to create a new team


### PR DESCRIPTION
There is still scope for improvement in this feature. The front-end is calling for the list of coinblocks to be changed once every three seconds. It would be much better if the list was called (by calling the getQuestionList function in main.js) every time submit is clicked, for an "instant" feel.